### PR TITLE
reload php worker when php file change detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Show PHP workers' status
 composer show-workers
 ```
 
+Watch PHP source code change and reload PHP workers
+```
+composer show-workers
+```
+
+
 ## Directory structure
 - [containers](containers) contains Dockerfile for RoadRunner.
 - etc/roadrunner contains RoadRunner config files.

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         ],
         "show-workers": [
             "docker exec roadrunner rr -c /etc/roadrunner/.rr.yaml http:workers -i"
+        ],
+        "watch": [
+            "docker exec roadrunner bash /var/www/app/watch.sh"
         ]
     },
     "config": {

--- a/containers/roadrunner/Dockerfile
+++ b/containers/roadrunner/Dockerfile
@@ -3,7 +3,9 @@ FROM php:7.3-cli
 RUN apt-get update && apt-get install -y --no-install-recommends \
   vim \
   libzip-dev \
-  unzip
+  unzip \
+  procps \
+  inotify-tools
 
 # Install PHP Extensions
 RUN docker-php-ext-install zip \

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pkill inotifywait
+
+inotifywait -r -e modify,close_write,moved_to,create -m /var/www/app |
+grep '\.php$' --line-buffered |
+grep -v '^/var/www/app/vendor/' --line-buffered |
+while read -r directory events filename; do
+  echo "${events}: ${directory}${filename}"
+  rr -c /etc/roadrunner/.rr.yaml http:reset
+done


### PR DESCRIPTION
enable hot reload with `composer watch`.

```
$ composer watch
> docker exec roadrunner bash /var/www/app/watch.sh
Setting up watches.  Beware: since -r was given, this may take a while!
Watches established.
MODIFY: /var/www/app/worker.php
Restarting http worker pool: done
```

