### PR TITLE
fixes #10 fix login command

### DIFF
--- a/containers/roadrunner/Dockerfile
+++ b/containers/roadrunner/Dockerfile
@@ -10,7 +10,8 @@ FROM ${PHP_IMAGE}
 RUN apk update && apk add --no-cache \
   vim \
   libzip-dev \
-  unzip
+  unzip \
+  bash
 
 # Install PHP Extensions
 RUN docker-php-ext-install zip \


### PR DESCRIPTION
`./task login` command has not been working because bash isn't contained in the alpine image.

#10 